### PR TITLE
fix(deps): bump keycloak.version from 15.0.2 to 18.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <revision>0.0.0-SNAPSHOT</revision>
         <java.version>1.8</java.version>
-        <keycloak.version>15.0.2</keycloak.version>
+        <keycloak.version>18.0.0</keycloak.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Bumps `keycloak.version` from 15.0.2 to 18.0.0.

Updates `keycloak-server-spi` from 15.0.2 to 18.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Commits](https://github.com/keycloak/keycloak/compare/15.0.2...18.0.0)

Updates `keycloak-server-spi-private` from 15.0.2 to 18.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Commits](https://github.com/keycloak/keycloak/compare/15.0.2...18.0.0)

Updates `keycloak-services` from 15.0.2 to 18.0.0
- [Release notes](https://github.com/keycloak/keycloak/releases)
- [Commits](https://github.com/keycloak/keycloak/compare/15.0.2...18.0.0)

---
updated-dependencies:
- dependency-name: org.keycloak:keycloak-server-spi
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.keycloak:keycloak-server-spi-private
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: org.keycloak:keycloak-services
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>